### PR TITLE
Add serde support and remove dead code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ structopt = "0.3.7"
 strum = "0.21.0"
 strum_macros = "0.21.1"
 tracing = "0.1.10"
+serde = { version = "1.0.126", features = ["derive"] }
 
 [dependencies.log]
 features = ["max_level_debug"]

--- a/src/common/entry.rs
+++ b/src/common/entry.rs
@@ -1,4 +1,3 @@
-use std::fmt::Debug;
 /**
  * rust-kad
  * Kademlia node type
@@ -6,27 +5,21 @@ use std::fmt::Debug;
  * https://github.com/ryankurte/rust-kad
  * Copyright 2018 Ryan Kurte
  */
+use std::fmt::Debug;
 use std::time::Instant;
+use serde::{Serialize, Deserialize};
 
 use super::id::DatabaseId;
 
 /// Entry is a node entry in the DHT
 /// This is generic over Id and Info and intended to be cheaply cloned
 /// as a container for unique information
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Entry<Id, Info> {
     id: Id,
     info: Info,
+    #[serde(skip)]
     seen: Option<Instant>,
-    state: EntryState,
-    frozen: bool,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum EntryState {
-    Ok,
-    Expiring,
-    Expired,
 }
 
 impl<Id, Info> PartialEq for Entry<Id, Info>
@@ -49,8 +42,6 @@ where
             id,
             info,
             seen: None,
-            frozen: false,
-            state: EntryState::Ok,
         }
     }
 

--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -6,8 +6,9 @@
  * Copyright 2018 Ryan Kurte
  */
 use super::entry::Entry;
+use serde::{Serialize, Deserialize};
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum Request<Id, Value> {
     Ping,
     FindNode(Id),
@@ -39,7 +40,7 @@ impl<Id, Value> Request<Id, Value> {
     }
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum Response<Id, Info, Value> {
     NodesFound(Id, Vec<Entry<Id, Info>>),
     ValuesFound(Id, Vec<Value>),


### PR DESCRIPTION
I think being able to (de-)serialize messages is a basic requirement for using this library in a real multi-computer setup. I've also removed some dead code (`EntryState`) along the way.